### PR TITLE
crs-2477-reason-for-missing-information

### DIFF
--- a/assets/scss/local.scss
+++ b/assets/scss/local.scss
@@ -14,7 +14,7 @@
 }
 
 .moj-interruption-card__body {
-   .govuk-details {  
+   .govuk-details {
     * {
       color: white;
     }
@@ -30,6 +30,12 @@
     }
   }
 }
+
 .autocomplete__option {
   font-family: "GDS Transport", arial, sans-serif;
+}
+
+.manual-entry-inset-test {
+  background-color: #f3f2f1;
+  width: 80%;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "connect-redis": "^9.0.0",
         "csrf-sync": "^4.2.1",
         "csv-stringify": "^6.7.0",
-        "dayjs": "^1.11.20",
+        "dayjs": "1.11.21",
         "express": "^5.2.1",
         "express-prom-bundle": "^8.0.0",
         "express-session": "^1.19.0",
@@ -43,7 +43,8 @@
         "serialize-javascript": "7.0.5",
         "superagent": "^10.3.0",
         "url-value-parser": "^2.2.0",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@jgoz/esbuild-plugin-typecheck": "^4.0.4",
@@ -7726,9 +7727,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.20",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
-      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -17949,6 +17950,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "connect-redis": "^9.0.0",
     "csrf-sync": "^4.2.1",
     "csv-stringify": "^6.7.0",
-    "dayjs": "^1.11.20",
+    "dayjs": "1.11.21",
     "express": "^5.2.1",
     "express-prom-bundle": "^8.0.0",
     "express-session": "^1.19.0",

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -13,6 +13,7 @@ declare module 'express-session' {
     storedCalculations?: Record<string, RemandResult>
     storedCalculationsWithoutSelection?: Record<string, RemandResult>
     rejectedRemandDecision?: Record<string, IdentifyRemandDecision>
+    reasonForMissingInformation?: Record<string, string>
   }
 }
 

--- a/server/@types/identifyRemandPeriods/index.d.ts
+++ b/server/@types/identifyRemandPeriods/index.d.ts
@@ -198,6 +198,7 @@ export interface components {
     IdentifyRemandDecisionDto: {
       accepted: boolean
       rejectComment?: string
+      reasonForMissingInformation?: string
       options?: components['schemas']['RemandCalculationRequestOptions']
       /** Format: int32 */
       days?: number

--- a/server/middleware/asyncMiddleware.ts
+++ b/server/middleware/asyncMiddleware.ts
@@ -1,7 +1,0 @@
-import type { Request, Response, NextFunction, RequestHandler } from 'express'
-
-export default function asyncMiddleware(fn: RequestHandler) {
-  return (req: Request, res: Response, next: NextFunction): void => {
-    Promise.resolve(fn(req, res, next)).catch(next)
-  }
-}

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -2,10 +2,9 @@ import { jwtDecode } from 'jwt-decode'
 import type { RequestHandler } from 'express'
 
 import logger from '../../logger'
-import asyncMiddleware from './asyncMiddleware'
 
 export default function authorisationMiddleware(authorisedRoles: string[] = []): RequestHandler {
-  return asyncMiddleware((req, res, next) => {
+  return (req, res, next) => {
     // authorities in the user token will always be prefixed by ROLE_.
     // Convert roles that are passed into this function without the prefix so that we match correctly.
     const authorisedAuthorities = authorisedRoles.map(role => (role.startsWith('ROLE_') ? role : `ROLE_${role}`))
@@ -22,5 +21,5 @@ export default function authorisationMiddleware(authorisedRoles: string[] = []):
 
     req.session.returnTo = req.originalUrl
     return res.redirect('/sign-in')
-  })
+  }
 }

--- a/server/model/ReasonForMissingInformationForm.ts
+++ b/server/model/ReasonForMissingInformationForm.ts
@@ -1,0 +1,26 @@
+import AbstractForm from './abstractForm'
+import ValidationError from './validationError'
+
+export default class ReasonForMissingInformationForm extends AbstractForm<ReasonForMissingInformationForm> {
+  nomsId: string
+
+  reasonForMissingInformation: string
+
+  constructor(nomsId: string, params: Partial<ReasonForMissingInformationForm>) {
+    super(params)
+    this.nomsId = nomsId
+    this.reasonForMissingInformation = params?.reasonForMissingInformation
+  }
+
+  validation(): ValidationError[] {
+    if (!this.reasonForMissingInformation || !this.reasonForMissingInformation.trim()) {
+      return [
+        {
+          text: 'Enter a reason for missing information',
+          fields: ['reasonForMissingInformation'],
+        },
+      ]
+    }
+    return []
+  }
+}

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -1,14 +1,13 @@
 import { type RequestHandler, Router } from 'express'
 
-import asyncMiddleware from '../middleware/asyncMiddleware'
 import type { Services } from '../services'
 import RemandRoutes from './remandRoutes'
 import PrisonerImageRoutes from './prisonerImageRoutes'
 
 export default function routes(service: Services): Router {
   const router = Router()
-  const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
-  const post = (path: string, handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
+  const get = (path: string | string[], handler: RequestHandler) => router.get(path, handler)
+  const post = (path: string, handler: RequestHandler) => router.post(path, handler)
 
   const remandRoutes = new RemandRoutes(
     service.prisonerService,
@@ -28,6 +27,9 @@ export default function routes(service: Services): Router {
   get('/prisoner/:nomsId', remandRoutes.entry)
 
   get('/prisoner/:nomsId/validation-errors', remandRoutes.validationErrors)
+
+  get('/prisoner/:nomsId/reason-for-missing-information', remandRoutes.reasonForMissingInformation)
+  post('/prisoner/:nomsId/reason-for-missing-information', remandRoutes.reasonForMissingInformationSubmit)
 
   get('/prisoner/:nomsId/replaced-offence-intercept', remandRoutes.replacedOffenceIntercept)
 

--- a/server/routes/remandRoutes.test.ts
+++ b/server/routes/remandRoutes.test.ts
@@ -623,8 +623,9 @@ describe('Validation error page /prisoner/{prisonerId}/validation-errors', () =>
           'There is information missing in NOMIS that could impact the remand time.',
           'This is an important message',
           'This is also important message',
-          'To ensure the remand time is calculated correctly, add the missing information in NOMIS, then ',
+          '<h2>What you need to do</h2>',
         ])
+        expect(res.text).toContain('you can enter the remand time manually.')
       })
   })
   it('Should display error page without cached result', () => {
@@ -648,8 +649,9 @@ describe('Validation error page /prisoner/{prisonerId}/validation-errors', () =>
           'There is information missing in NOMIS that could impact the remand time.',
           'This is an important message',
           'This is also important message',
-          'To ensure the remand time is calculated correctly, add the missing information in NOMIS, then ',
+          '<h2>What you need to do</h2>',
         ])
+        expect(res.text).toContain('you can enter the remand time manually.')
       })
   })
   it('Should display redirect with no errors', () => {
@@ -845,6 +847,29 @@ describe('Confirm and save /prisoner/{prisonerId}/confirm-and-save', () => {
         expect(res.text).toContain('The remand tool suggested the below remand')
         expect(res.text).toContain('The reason for rejection was: <strong>Rejected</strong>')
         expect(calculateReleaseDatesService.unusedDeductionsHandlingCRDError.mock.calls.length).toBe(0)
+      })
+  })
+
+  it('Should show reason form missing information when bypassing validation', () => {
+    prisonerService.getSentencesAndOffences.mockResolvedValue([
+      {
+        offences: [
+          {
+            offenceStatute: 'WR91',
+          },
+        ],
+        caseReference: 'CASE1234',
+        sentenceStatus: 'A',
+      },
+    ])
+    cachedDataService.getCalculationWithoutSelections.mockResolvedValue(remandResult)
+    cachedDataService.getCalculation.mockResolvedValue(remandResult)
+    cachedDataService.getReasonForMissingInformation.mockReturnValue('missing NOMIS data')
+    return request(app)
+      .get(`/prisoner/${NOMS_ID}/reason-for-missing-information`)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).toContain('<a href="/prisoner/ABC123/validation-errors" class="govuk-back-link">Back</a>')
       })
   })
 

--- a/server/routes/remandRoutes.ts
+++ b/server/routes/remandRoutes.ts
@@ -1,4 +1,4 @@
-import { RequestHandler } from 'express'
+import { Request, RequestHandler } from 'express'
 import { stringify } from 'csv-stringify'
 import PrisonerService from '../services/prisonerService'
 import BulkRemandCalculationService from '../services/bulkRemandCalculationService'
@@ -19,6 +19,7 @@ import DetailedRemandCalculation from '../model/DetailedRemandCalculation'
 import DetailedRemandCalculationAndSentence from '../model/DetailedRemandCalculationAndSentence'
 import RemandOverviewModel from '../model/RemandOverviewModel'
 import { sameMembers } from '../utils/utils'
+import ReasonForMissingInformationForm from '../model/ReasonForMissingInformationForm'
 
 export default class RemandRoutes {
   constructor(
@@ -70,20 +71,70 @@ export default class RemandRoutes {
     const nomsId = req.params.nomsId as string
     const { bookingId } = res.locals.prisoner
 
-    const sentencesAndOffences = await this.prisonerService.getSentencesAndOffences(bookingId, username)
-    const calculation = await this.cachedDataService.getCalculationWithoutSelections(req, nomsId, username, true)
+    const detailedRemandAndSentence = await this.getDetailedRemandAndSentence(bookingId, req, nomsId, username)
 
-    const detailedCalculation = new DetailedRemandCalculation(calculation)
-    const detailedRemandAndSentence = new DetailedRemandCalculationAndSentence(
-      detailedCalculation,
-      sentencesAndOffences,
-    )
     if (detailedRemandAndSentence.mostImportantErrors().length) {
       return res.render('pages/remand/validation-errors', {
         model: detailedRemandAndSentence,
+        nomsId,
       })
     }
     return res.redirect(`/prisoner/${nomsId}`)
+  }
+
+  public reasonForMissingInformation: RequestHandler = async (req, res): Promise<void> => {
+    const { username } = res.locals.user
+    const nomsId = req.params.nomsId as string
+    const { bookingId } = res.locals.prisoner
+
+    const detailedRemandAndSentence = await this.getDetailedRemandAndSentence(bookingId, req, nomsId, username)
+
+    // Ensure validation errors are present before prompting for missing information.
+    if (detailedRemandAndSentence.mostImportantErrors().length === 0) {
+      return res.redirect(`/prisoner/${nomsId}`)
+    }
+
+    const existingReason = this.cachedDataService.getReasonForMissingInformation(req, nomsId)
+    const reasonForMissingInformationForm = new ReasonForMissingInformationForm(nomsId, {
+      reasonForMissingInformation: existingReason,
+    })
+
+    return res.render('pages/remand/reason-for-missing-information', {
+      model: reasonForMissingInformationForm,
+    })
+  }
+
+  public reasonForMissingInformationSubmit: RequestHandler = async (req, res): Promise<void> => {
+    const nomsId = req.params.nomsId as string
+    const { username } = res.locals.user
+    const reasonForMissingInformationForm = new ReasonForMissingInformationForm(nomsId, req.body)
+    this.cachedDataService.setReasonForMissingInformation(
+      req,
+      nomsId,
+      reasonForMissingInformationForm.reasonForMissingInformation,
+    )
+
+    reasonForMissingInformationForm.validate()
+
+    if (reasonForMissingInformationForm.errors.length) {
+      return res.render('pages/remand/reason-for-missing-information', {
+        model: reasonForMissingInformationForm,
+      })
+    }
+
+    const decision: IdentifyRemandDecision = {
+      accepted: false,
+      rejectComment: 'missing NOMIS information',
+      reasonForMissingInformation: reasonForMissingInformationForm.reasonForMissingInformation,
+      options: {
+        includeRemandCalculation: false,
+        userSelections: [],
+      },
+    }
+
+    await this.identifyRemandPeriodsService.saveRemandDecision(nomsId, decision, username)
+    this.cachedDataService.clearReasonForMissingInformation(req, nomsId)
+    return res.redirect(`${config.services.adjustmentServices.url}/${nomsId}/remand/add`)
   }
 
   public replacedOffenceIntercept: RequestHandler = async (req, res): Promise<void> => {
@@ -384,5 +435,13 @@ export default class RemandRoutes {
           curr.every(chargeId => prev.chargeIdsToMakeApplicable.indexOf(chargeId) >= 0),
       ),
     )
+  }
+
+  async getDetailedRemandAndSentence(bookingId: string, req: Request, nomsId: string, username: string) {
+    const sentencesAndOffences = await this.prisonerService.getSentencesAndOffences(bookingId, username)
+    const calculation = await this.cachedDataService.getCalculationWithoutSelections(req, nomsId, username, true)
+
+    const detailedCalculation = new DetailedRemandCalculation(calculation)
+    return new DetailedRemandCalculationAndSentence(detailedCalculation, sentencesAndOffences)
   }
 }

--- a/server/services/cachedDataService.ts
+++ b/server/services/cachedDataService.ts
@@ -102,6 +102,21 @@ export default class CachedDataService {
     req.session.rejectedRemandDecision[nomsId] = undefined
   }
 
+  public getReasonForMissingInformation(req: Request, nomsId: string): string {
+    this.initialiseSession(req, nomsId)
+    return req.session.reasonForMissingInformation[nomsId]
+  }
+
+  public setReasonForMissingInformation(req: Request, nomsId: string, reason: string): void {
+    this.initialiseSession(req, nomsId)
+    req.session.reasonForMissingInformation[nomsId] = reason
+  }
+
+  public clearReasonForMissingInformation(req: Request, nomsId: string): void {
+    this.initialiseSession(req, nomsId)
+    req.session.reasonForMissingInformation[nomsId] = undefined
+  }
+
   private initialiseSession(req: Request, nomsId: string) {
     if (!req.session.selectedApplicableRemand) {
       req.session.selectedApplicableRemand = {}
@@ -120,6 +135,12 @@ export default class CachedDataService {
     }
     if (!req.session.rejectedRemandDecision[nomsId]) {
       req.session.rejectedRemandDecision[nomsId] = undefined
+    }
+    if (!req.session.reasonForMissingInformation) {
+      req.session.reasonForMissingInformation = {}
+    }
+    if (!req.session.reasonForMissingInformation[nomsId]) {
+      req.session.reasonForMissingInformation[nomsId] = undefined
     }
   }
 }

--- a/server/views/pages/remand/reason-for-missing-information.njk
+++ b/server/views/pages/remand/reason-for-missing-information.njk
@@ -1,0 +1,70 @@
+{% extends "../../partials/layout.njk" %}
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+
+{% set pageTitle = applicationName + " - Reason for missing information " %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+    {{ super() }}
+    <nav>
+        {% set backlink = '/prisoner/' + model.nomsId + '/validation-errors' %}
+        {{ govukBackLink({
+            text: "Back",
+            href: backlink
+        }) }}
+    </nav>
+{% endblock %}
+
+{% block content %}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">
+            <span class="govuk-caption-xl">Review remand</span>
+            Provide a reason why you cannot add the missing information.
+        </h1>
+        {% if model.errors.length %}
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    {{ govukErrorSummary({
+                        titleText: "There is a problem",
+                        errorList: model.errorList()
+                    }) }}
+                </div>
+            </div>
+        {% endif %}
+        <form class="form" method="post">
+            <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+            {{ govukTextarea({
+                name: "reasonForMissingInformation",
+                id: "reason-for-missing-information",
+                label: {
+                    text: "This will help us understand how we can improve the service.",
+                    classes: "govuk-label --s",
+                    isPageHeading: true
+                },
+                value: model.reasonForMissingInformation
+            }) }}
+            <div class="govuk-button-group">
+                {{ govukButton({
+                    text: "Continue",
+                    type: submit,
+                    preventDoubleClick: true,
+                    attributes: { 'data-qa': 'submit-form' }
+                }) }}
+                {{ govukButton({
+                    text: "Cancel",
+                    classes: "govuk-button--secondary",
+                    href: '/prisoner/' + model.nomsId + '/validation-errors'
+                }) }}
+            </div>
+        </form>
+    </div>
+</div>
+
+{% endblock %}

--- a/server/views/pages/remand/validation-errors.njk
+++ b/server/views/pages/remand/validation-errors.njk
@@ -8,23 +8,26 @@
 
 {% block content %}
 
-    {% set errorBody %}
-        <div class="govuk-error-summary__body">
-            <p>There is information missing in NOMIS that could impact the remand time.</p>
-            <ul class="govuk-list govuk-error-summary__list">
-                {% for error in model.mostImportantErrors() %}
-                    <li>
-                        <p class="govuk-body">{{error.message}}</p>
-                    </li>
-                {% endfor %}
-            </ul>
-            <p class="govuk-!-margin-top-4">To ensure the remand time is calculated correctly, add the missing information in NOMIS, then <a href="">reload this page</a>.</p>
-        </div>
-    {% endset -%}
+    <div class="govuk-grid-column-full">
+        <h1 class="govuk-heading-l">
+            <span class="govuk-caption-xl">Review remand</span>
+            Update the NOMIS information
+        </h1>
 
-    {{ govukErrorSummary({
-        titleText: "There is a problem",
-        errorList: [],
-        descriptionHtml: errorBody
-    }) }}
+        <p class="govuk-body">There is information missing in NOMIS that could impact the remand time.</p>
+
+        What needs updating:
+
+        <ul>
+        {% for error in model.mostImportantErrors() %}
+            <li>
+                <p>{{error.message}}</p>
+            </li>
+        {% endfor %}
+        </ul>
+    <h2>What you need to do</h2>
+    <p>Update the information in NOMIS, then <a href="">reload this page</a></p>
+    <p>If you cannot find the documentation for the missing information, <a href="{{ '/prisoner/' + nomsId + '/reason-for-missing-information' }}">you can enter the remand time manually.</a></p>
+    </div>
+
 {% endblock %}


### PR DESCRIPTION
Add option to bypass validation. Prompt user to enter reason for missing NOMIS information, then submit rejected remand to allow for manual entry within the adjustments service.

Remove redundant async middleware.