### PR TITLE
CRS-2782: Small UI tweaks

### DIFF
--- a/server/model/RelevantRemandModel.ts
+++ b/server/model/RelevantRemandModel.ts
@@ -29,6 +29,7 @@ export default class RelevantRemandModel extends RemandCardModel {
     sentencesAndOffences: PrisonApiOffenderSentenceAndOffences[],
     public selections: RemandApplicableUserSelection[],
     private existingAdjustments: Adjustment[],
+    private calculationWithoutSelections: RemandResult,
   ) {
     super(prisonerNumber, relevantRemand, sentencesAndOffences)
     const chargeRemandAndCharges = this.relevantRemand.chargeRemand.map(it =>
@@ -90,5 +91,16 @@ export default class RelevantRemandModel extends RemandCardModel {
 
   public detailedBreakdownLink() {
     return `/prisoner/${this.prisonerNumber}/detailed-breakdown`
+  }
+
+  public backLink(): string | null {
+    const replaceableCharges = new DetailedRemandCalculation(
+      this.calculationWithoutSelections,
+    ).getReplaceableChargeRemandGroupedByChargeIds()
+    if (replaceableCharges && replaceableCharges.length > 0) {
+      const nextChargeIds = replaceableCharges[replaceableCharges.length - 1].chargeIds.join(',')
+      return `/prisoner/${this.prisonerNumber}/replaced-offence?chargeIds=${nextChargeIds}`
+    }
+    return null
   }
 }

--- a/server/routes/remandRoutes.test.ts
+++ b/server/routes/remandRoutes.test.ts
@@ -1,5 +1,6 @@
 import type { Express } from 'express'
 import request from 'supertest'
+import * as cheerio from 'cheerio'
 import { appWithAllRoutes, user } from './testutils/appSetup'
 import PrisonerService from '../services/prisonerService'
 import IdentifyRemandPeriodsService from '../services/identifyRemandPeriodsService'
@@ -312,6 +313,7 @@ describe('Remand results page /prisoner/{prisonerId}/remand', () => {
       },
     ])
     cachedDataService.getCalculation.mockResolvedValue(remandResult)
+    cachedDataService.getCalculationWithoutSelections.mockResolvedValue(remandResult)
     adjustmentsService.findByPerson.mockResolvedValue([
       {
         days: 10,
@@ -322,6 +324,10 @@ describe('Remand results page /prisoner/{prisonerId}/remand', () => {
       .get(`/prisoner/${NOMS_ID}/remand`)
       .expect('Content-Type', /html/)
       .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-qa=back-link]').attr('href')).toStrictEqual(
+          '/prisoner/ABC123/replaced-offence?chargeIds=3933924',
+        )
         expect(res.text).toContainInOrder([
           'There is information missing in NOMIS that could impact the remand time.',
           'This is an important message',
@@ -348,6 +354,7 @@ describe('Remand results page /prisoner/{prisonerId}/remand', () => {
       },
     ])
     cachedDataService.getCalculation.mockResolvedValue(emptyRemandResult)
+    cachedDataService.getCalculationWithoutSelections.mockResolvedValue(emptyRemandResult)
     adjustmentsService.findByPerson.mockResolvedValue([
       {
         days: 0,
@@ -358,6 +365,8 @@ describe('Remand results page /prisoner/{prisonerId}/remand', () => {
       .get(`/prisoner/${NOMS_ID}/remand`)
       .expect('Content-Type', /html/)
       .expect(res => {
+        const $ = cheerio.load(res.text)
+        expect($('[data-qa=back-link]')).toHaveLength(0)
         expect(res.text).toContain(
           'Explain why there should be remand to be applied. This will help our support team improve the accuracy of the remand tool.',
         )
@@ -377,6 +386,7 @@ describe('Remand results page /prisoner/{prisonerId}/remand', () => {
       },
     ])
     cachedDataService.getCalculation.mockResolvedValue(onePlusremandDaysRemandResult)
+    cachedDataService.getCalculationWithoutSelections.mockResolvedValue(onePlusremandDaysRemandResult)
     adjustmentsService.findByPerson.mockResolvedValue([
       {
         days: 10,
@@ -407,6 +417,7 @@ describe('Remand results page /prisoner/{prisonerId}/remand', () => {
       },
     ])
     cachedDataService.getCalculation.mockResolvedValue(emptyRemandResult)
+    cachedDataService.getCalculationWithoutSelections.mockResolvedValue(emptyRemandResult)
     adjustmentsService.findByPerson.mockResolvedValue([
       {
         days: 10,

--- a/server/routes/remandRoutes.ts
+++ b/server/routes/remandRoutes.ts
@@ -169,6 +169,12 @@ export default class RemandRoutes {
     const { bookingId, prisonerNumber } = res.locals.prisoner
     const selections = this.cachedDataService.getSelections(req, nomsId)
     const calculation = await this.cachedDataService.getCalculation(req, nomsId, username, true)
+    const calculationWithoutSelections = await this.cachedDataService.getCalculationWithoutSelections(
+      req,
+      nomsId,
+      username,
+      false,
+    )
     const sentencesAndOffences = await this.prisonerService.getSentencesAndOffences(bookingId, username)
 
     return res.render('pages/remand/results', {
@@ -178,6 +184,7 @@ export default class RemandRoutes {
         sentencesAndOffences,
         selections,
         await this.adjustmentsService.findByPerson(nomsId, username),
+        calculationWithoutSelections,
       ),
       form: new RemandDecisionForm({}),
     })
@@ -193,6 +200,12 @@ export default class RemandRoutes {
     if (form.errors.length) {
       const calculation = await this.cachedDataService.getCalculation(req, nomsId, username)
       const sentencesAndOffences = await this.prisonerService.getSentencesAndOffences(bookingId, username)
+      const calculationWithoutSelections = await this.cachedDataService.getCalculationWithoutSelections(
+        req,
+        nomsId,
+        username,
+        false,
+      )
       return res.render('pages/remand/results', {
         model: new RelevantRemandModel(
           prisonerNumber,
@@ -200,6 +213,7 @@ export default class RemandRoutes {
           sentencesAndOffences,
           selections,
           await this.adjustmentsService.findByPerson(nomsId, username),
+          calculationWithoutSelections,
         ),
         form,
       })

--- a/server/views/autherror.njk
+++ b/server/views/autherror.njk
@@ -1,7 +1,7 @@
 {% extends "./partials/layout.njk" %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl">
+  <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
     Authorisation Error
   </h1>
   <p>

--- a/server/views/maintenance.njk
+++ b/server/views/maintenance.njk
@@ -1,7 +1,7 @@
 {% extends "./partials/layout.njk" %}
 
 {% block content %}
-  <h1 class="govuk-heading-xl" data-qa="oos-header">Sorry, there is a problem with the service</h1>
+  <h1 class="govuk-heading-xl govuk-!-margin-bottom-4" data-qa="oos-header">Sorry, there is a problem with the service</h1>
   <p class="govuk-body">Try again later.</p>
   <p class="govuk-body">We have not saved your answers. When the service is available, you will have to start again.</p>
   <p class="govuk-body">Contact the Court cases and release dates team if you have any questions.</p>

--- a/server/views/pages/remand/bulk-in-progress.njk
+++ b/server/views/pages/remand/bulk-in-progress.njk
@@ -11,7 +11,7 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <h1 class="govuk-heading-xl">
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
                 <span class="govuk-caption-xl">Bulk Comparison</span>
                 {% if status == "RUNNING" %}
                     Calculation in progress

--- a/server/views/pages/remand/confirm-and-save.njk
+++ b/server/views/pages/remand/confirm-and-save.njk
@@ -40,7 +40,7 @@
   </div>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <h1 class="govuk-heading-xl">
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
         <span class="govuk-caption-xl">Review remand</span>
         Confirm and save
       </h1>

--- a/server/views/pages/remand/detailed-breakdown.njk
+++ b/server/views/pages/remand/detailed-breakdown.njk
@@ -63,7 +63,7 @@
     {% endif %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <h1 class="govuk-heading-xl">
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
                 <span class="govuk-caption-xl">Review remand</span>
                 Remand breakdown
             </h1>
@@ -90,7 +90,7 @@
                     {% for remand in model.relevantRemandBreakdowns %}
                         {{ remandBreakdown(remand)}}
                         {% if not loop.last %}
-                        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+                        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-6">
                         {% endif %}
                     {% endfor %}
                 {% else %}
@@ -102,7 +102,7 @@
                         {% for remand in model.notRelevantRemandBreakdowns %}
                             {{ remandBreakdown(remand)}}
                             {% if not loop.last %}
-                            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+                            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible govuk-!-margin-bottom-6">
                             {% endif %}
                         {% endfor %}
                     {% endset %}
@@ -147,4 +147,10 @@
             {% endif %}
         </div>
     </div>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+           <a href="{{ backlink }}" class="govuk-link--no-visited-state">Back to remand summary</a>
+        </div>
+    </div>
+
 {% endblock %}

--- a/server/views/pages/remand/overview.njk
+++ b/server/views/pages/remand/overview.njk
@@ -23,7 +23,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-xl">
+      <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
         <span class="govuk-caption-xl">Adjustments</span>
         Remand overview
       </h1>

--- a/server/views/pages/remand/reason-for-missing-information.njk
+++ b/server/views/pages/remand/reason-for-missing-information.njk
@@ -24,7 +24,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-xl">
+        <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
             <span class="govuk-caption-xl">Review remand</span>
             Provide a reason why you cannot add the missing information.
         </h1>

--- a/server/views/pages/remand/results.njk
+++ b/server/views/pages/remand/results.njk
@@ -8,11 +8,26 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "../../components/remand-table/macro.njk" import remandTable %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Home" %}
 {% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+    {{ super() }}
+    <nav>
+        {% set backLink = model.backLink() %}
+        {% if backLink %}
+            {{ govukBackLink({
+                text: "Back",
+                href: backLink,
+                attributes: { "data-qa": "back-link" }
+            }) }}
+        {% endif %}
+    </nav>
+{% endblock %}
 
 {% block content %}
 
@@ -64,7 +79,7 @@
     {% endif %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            <h1 class="govuk-heading-xl">
+            <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
                 <span class="govuk-caption-xl">Review remand</span>
                 Check remand details for {{prisoner.firstName | title}} {{prisoner.lastName | title}}
             </h1>

--- a/server/views/pages/remand/validation-errors.njk
+++ b/server/views/pages/remand/validation-errors.njk
@@ -9,7 +9,7 @@
 {% block content %}
 
     <div class="govuk-grid-column-full">
-        <h1 class="govuk-heading-xl">
+        <h1 class="govuk-heading-xl govuk-!-margin-bottom-4">
             <span class="govuk-caption-xl">Review remand</span>
             Update the NOMIS information
         </h1>


### PR DESCRIPTION
Adjust spacing of headers to match figma.
Add missing link at bottom of breakdown page
Add back link to remand result when there were replacable charges as there is now no edit link.